### PR TITLE
move from jsonpath_lib to jsonpath-rust to eliminate indexmap use in serde_json.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,7 +30,8 @@ assert-json-diff = "2.0.1"
 garde = { version = "0.16.1", default-features = false, features = ["derive"] }
 anyhow = "1.0.44"
 futures = "0.3.17"
-jsonpath_lib = "0.3.0"
+jsonpath_lib = { git = "https://github.com/gregcusack/jsonpath.git", branch = "json-mod" }
+jsonpath-rust = { git = "https://github.com/gregcusack/jsonpath-rust.git", branch = "mod-json" }
 kube = { path = "../kube", version = "^0.87.1", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.87.1", default-features = false } # only needed to opt out of schema
 k8s-openapi = { version = "0.20.0", default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,7 +30,6 @@ assert-json-diff = "2.0.1"
 garde = { version = "0.16.1", default-features = false, features = ["derive"] }
 anyhow = "1.0.44"
 futures = "0.3.17"
-jsonpath_lib = { git = "https://github.com/gregcusack/jsonpath.git", branch = "json-mod" }
 jsonpath-rust = { git = "https://github.com/gregcusack/jsonpath-rust.git", branch = "mod-json" }
 kube = { path = "../kube", version = "^0.87.1", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.87.1", default-features = false } # only needed to opt out of schema

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,7 +30,7 @@ assert-json-diff = "2.0.1"
 garde = { version = "0.16.1", default-features = false, features = ["derive"] }
 anyhow = "1.0.44"
 futures = "0.3.17"
-jsonpath-rust = { git = "https://github.com/gregcusack/jsonpath-rust.git", branch = "mod-json" }
+jsonpath-rust = "0.3.4"
 kube = { path = "../kube", version = "^0.87.1", default-features = false, features = ["admission"] }
 kube-derive = { path = "../kube-derive", version = "^0.87.1", default-features = false } # only needed to opt out of schema
 k8s-openapi = { version = "0.20.0", default-features = false }

--- a/examples/dynamic_jsonpath.rs
+++ b/examples/dynamic_jsonpath.rs
@@ -26,6 +26,21 @@ async fn main() -> anyhow::Result<()> {
     // Use the given JSONPATH to filter the ObjectList
     let list_json = serde_json::to_value(&list)?;
     let res = jsonpath_lib::select(&list_json, &jsonpath).unwrap();
-    info!("\t\t {:?}", res);
+    info!("greg 1 res: \t\t {:?}", res);
+
+    let json_str = list_json.to_string();
+    let jsonpath = jsonpath_rust::JsonPathFinder::from_str(json_str.as_str(), jsonpath.as_str()).unwrap();
+    let val: Vec<serde_json::Value> = jsonpath.find_slice()
+            .into_iter()
+            .filter(|v| v.has_value())
+            .map(|v| v.to_data())
+            .collect();
+    info!("greg 1 val: \t\t {:?}", val);
+
+    let val2: Vec<&serde_json::Value> = val.iter().map(|s| s).collect();
+
+    assert_eq!(res, val2);
+
+
     Ok(())
 }

--- a/examples/dynamic_jsonpath.rs
+++ b/examples/dynamic_jsonpath.rs
@@ -25,22 +25,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Use the given JSONPATH to filter the ObjectList
     let list_json = serde_json::to_value(&list)?;
-    let res = jsonpath_lib::select(&list_json, &jsonpath).unwrap();
-    info!("greg 1 res: \t\t {:?}", res);
-
     let json_str = list_json.to_string();
     let jsonpath = jsonpath_rust::JsonPathFinder::from_str(json_str.as_str(), jsonpath.as_str()).unwrap();
-    let val: Vec<serde_json::Value> = jsonpath.find_slice()
-            .into_iter()
-            .filter(|v| v.has_value())
-            .map(|v| v.to_data())
-            .collect();
-    info!("greg 1 val: \t\t {:?}", val);
-
-    let val2: Vec<&serde_json::Value> = val.iter().map(|s| s).collect();
-
-    assert_eq!(res, val2);
-
-
+    let v: Vec<serde_json::Value> = jsonpath.find_slice()
+        .into_iter()
+        .filter(|v| v.has_value())
+        .map(|v| v.to_data())
+        .collect();
+    let res: Vec<&serde_json::Value> = v.iter().map(|s| s).collect();
+    info!("\t\t {:?}", res);
     Ok(())
 }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -23,7 +23,7 @@ ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]
 oauth = ["client", "tame-oauth"]
 oidc = ["client", "form_urlencoded"]
 gzip = ["client", "tower-http/decompression-gzip"]
-client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath_lib", "bytes", "futures", "tokio", "tokio-util", "either"]
+client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath-rust", "bytes", "futures", "tokio", "tokio-util", "either"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 config = ["__non_core", "pem", "home"]
@@ -56,7 +56,7 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "=0.87.1" }
-jsonpath_lib = { version = "0.3.0", optional = true }
+jsonpath-rust = { version = "0.3.4", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -23,7 +23,7 @@ ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]
 oauth = ["client", "tame-oauth"]
 oidc = ["client", "form_urlencoded"]
 gzip = ["client", "tower-http/decompression-gzip"]
-client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath-rust", "bytes", "futures", "tokio", "tokio-util", "either"]
+client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath_lib", "bytes", "futures", "tokio", "tokio-util", "either"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 config = ["__non_core", "pem", "home"]
@@ -56,7 +56,7 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "=0.87.1" }
-jsonpath-rust = { version = "0.3.4", optional = true }
+jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -23,7 +23,7 @@ ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]
 oauth = ["client", "tame-oauth"]
 oidc = ["client", "form_urlencoded"]
 gzip = ["client", "tower-http/decompression-gzip"]
-client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath_lib", "jsonpath-rust", "bytes", "futures", "tokio", "tokio-util", "either"]
+client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath-rust", "bytes", "futures", "tokio", "tokio-util", "either"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 config = ["__non_core", "pem", "home"]
@@ -56,7 +56,6 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "=0.87.1" }
-jsonpath_lib = { git = "https://github.com/gregcusack/jsonpath.git", branch = "json-mod", optional = true }
 jsonpath-rust = { git = "https://github.com/gregcusack/jsonpath-rust.git", branch = "mod-json", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -56,7 +56,7 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "=0.87.1" }
-jsonpath-rust = { git = "https://github.com/gregcusack/jsonpath-rust.git", branch = "mod-json", optional = true }
+jsonpath-rust = { version = "0.3.4", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -23,7 +23,7 @@ ws = ["client", "tokio-tungstenite", "rand", "kube-core/ws", "tokio/macros"]
 oauth = ["client", "tame-oauth"]
 oidc = ["client", "form_urlencoded"]
 gzip = ["client", "tower-http/decompression-gzip"]
-client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath_lib", "bytes", "futures", "tokio", "tokio-util", "either"]
+client = ["config", "__non_core", "hyper", "http-body", "tower", "tower-http", "hyper-timeout", "pin-project", "chrono", "jsonpath_lib", "jsonpath-rust", "bytes", "futures", "tokio", "tokio-util", "either"]
 jsonpatch = ["kube-core/jsonpatch"]
 admission = ["kube-core/admission"]
 config = ["__non_core", "pem", "home"]
@@ -57,6 +57,7 @@ bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "=0.87.1" }
 jsonpath_lib = { git = "https://github.com/gregcusack/jsonpath.git", branch = "json-mod", optional = true }
+jsonpath-rust = { git = "https://github.com/gregcusack/jsonpath-rust.git", branch = "mod-json", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }

--- a/kube-client/Cargo.toml
+++ b/kube-client/Cargo.toml
@@ -56,7 +56,7 @@ rustls-pemfile = { version = "1.0.0", optional = true }
 bytes = { version = "1.1.0", optional = true }
 tokio = { version = "1.14.0", features = ["time", "signal", "sync"], optional = true }
 kube-core = { path = "../kube-core", version = "=0.87.1" }
-jsonpath_lib = { version = "0.3.0", optional = true }
+jsonpath_lib = { git = "https://github.com/gregcusack/jsonpath.git", branch = "json-mod", optional = true }
 tokio-util = { version = "0.7.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.13", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-rustls = { version = "0.24.0", optional = true }

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -10,7 +10,8 @@ use http::{
     header::{InvalidHeaderValue, AUTHORIZATION},
     HeaderValue, Request,
 };
-use jsonpath_lib::select as jsonpath_select;
+// use jsonpath_lib::select as jsonpath_select;
+use jsonpath_rust::select as jsonpath_select;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -11,7 +11,6 @@ use http::{
     HeaderValue, Request,
 };
 use jsonpath_lib::select as jsonpath_select;
-// use jsonpath_rust::select as jsonpath_select;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -11,6 +11,7 @@ use http::{
     HeaderValue, Request,
 };
 use jsonpath_lib::select as jsonpath_select;
+use jsonpath_rust::JsonPathFinder as jsonpath_finder;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -476,21 +477,33 @@ fn token_from_gcp_provider(provider: &AuthProviderConfig) -> Result<ProviderToke
 
 fn extract_value(json: &serde_json::Value, path: &str) -> Result<String, Error> {
     let pure_path = path.trim_matches(|c| c == '"' || c == '{' || c == '}');
-    match jsonpath_select(json, &format!("${pure_path}")) {
-        Ok(v) if !v.is_empty() => {
-            if let serde_json::Value::String(res) = v[0] {
-                Ok(res.clone())
-            } else {
-                Err(Error::AuthExec(format!(
-                    "Target value at {pure_path:} is not a string"
-                )))
-            }
-        }
+    
+    let json_str = json.as_str().unwrap();
+    let jsonpath = jsonpath_finder::from_str(json_str, pure_path).unwrap();
+    let res = serde_json::Value::Array(
+        jsonpath.find_slice()
+            .into_iter()
+            .filter(|v| v.has_value())
+            .map(|v| v.to_data())
+            .collect()
+    );
+    Ok(res.to_string())
 
-        Err(e) => Err(Error::AuthExec(format!("Could not extract JSON value: {e:}"))),
+    // match jsonpath_select(json, &format!("${pure_path}")) {
+    //     Ok(v) if !v.is_empty() => {
+    //         if let serde_json::Value::String(res) = v[0] {
+    //             Ok(res.clone())
+    //         } else {
+    //             Err(Error::AuthExec(format!(
+    //                 "Target value at {pure_path:} is not a string"
+    //             )))
+    //         }
+    //     }
 
-        _ => Err(Error::AuthExec(format!("Target value {pure_path:} not found"))),
-    }
+    //     Err(e) => Err(Error::AuthExec(format!("Could not extract JSON value: {e:}"))),
+
+    //     _ => Err(Error::AuthExec(format!("Target value {pure_path:} not found"))),
+    // }
 }
 
 /// ExecCredentials is used by exec-based plugins to communicate credentials to

--- a/kube-client/src/client/auth/mod.rs
+++ b/kube-client/src/client/auth/mod.rs
@@ -10,8 +10,8 @@ use http::{
     header::{InvalidHeaderValue, AUTHORIZATION},
     HeaderValue, Request,
 };
-// use jsonpath_lib::select as jsonpath_select;
-use jsonpath_rust::select as jsonpath_select;
+use jsonpath_lib::select as jsonpath_select;
+// use jsonpath_rust::select as jsonpath_select;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/kube-rs/kube-rs/blob/master/CONTRIBUTING.md
-->

## Motivation
`kube-client` relies on the crate `jsonpath_lib`. `jsonpath_lib` requires `serde_json` with the `preserve_order` feature. `preserve_order` tells `serde_json` to keep track of json using an `IndexMap` instead of the default `BTreeMap`. `IndexMap` performs slower than `BTreeMaps` as json sizes increase. json objects by definition are not ordered. 

Unfortunately, `jsonpath_lib` library seems to have been sunset. It has not been modified nor have any issues or pull requests been addressed in 2+ years, so we can't go to them to resolve this issue. 



<!--
Explain the context and why you're making that change. What is the problem you're trying to solve?
If a new feature is being added, describe the intended use case that feature fulfills.
-->

## Solution
So, here, we propose we use a similar library called `jsonpath-rust` as a replacement for `jsonpath_lib`. `jsonpath-rust` is actively being maintained. The `kube-client` only uses `jsonpath_lib` in two places. Both of those use cases can be replaced with the same functionality using `jsonpath-rust`.

This PR replaces the two instances of `jsonpath_lib` with the equivalent functionality using the actively maintained `jsonpath-rust`.

`jsonpath_lib` [crate](https://crates.io/crates/jsonpath_lib), [github](https://github.com/freestrings/jsonpath)
`jsonpath-rust` [crate](https://crates.io/crates/jsonpath-rust), [github](https://github.com/besok/jsonpath-rust)

This has been tested with both the unit and integration tests.


<!--
Summarize the solution and provide any necessary context needed to understand the code change.
-->
